### PR TITLE
[ci-artifacts] Adds per-job, artifact-generating workflows

### DIFF
--- a/.github/workflows/ci-flux-artifacts.yml
+++ b/.github/workflows/ci-flux-artifacts.yml
@@ -1,0 +1,105 @@
+name: ci-flux-artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  spindle-flux-ubuntu:
+    name: Testsuite (Flux, Ubuntu)
+    environment: Spindle CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@16feee727cbdc83b6a014e6cc26fec4a79bcf30c
+        with:
+          version: latest
+
+      - name: Build spindle-flux-ubuntu image
+        id: flux-ubuntu-build
+        run: |
+          cd containers/spindle-flux-ubuntu
+          docker compose --progress=plain build
+
+      - name: Bring spindle-flux-ubuntu up
+        id: flux-ubuntu-up
+        run: |
+          cd containers/spindle-flux-ubuntu
+          docker compose up -d --wait --wait-timeout 60
+
+      - name: Verify munge works in spindle-flux-ubuntu
+        id: flux-ubuntu-munge
+        run: |
+          docker exec node-1 bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-flux-ubuntu testsuite
+        id: flux-ubuntu-testsuite
+        run: |
+          docker exec node-1 bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 flux alloc --nodes=${workers} ./runTests --nodes=${workers} --tasks-per-node=3'
+
+      - name: Collect Spindle logs from containers
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          failed=0
+          for node in node-1 node-2 node-3 node-4; do
+            echo "::group::Collecting logs from $node"
+
+            if ! workdir=$(docker inspect -f '{{.Config.WorkingDir}}' "$node" 2>/dev/null); then
+              echo "Container $node not found; skipping."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -z "$workdir" ]; then
+              echo "WorkingDir empty for $node; cannot resolve log path."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            src="$workdir/Spindle-build/testsuite"
+            mkdir -p "spindle-logs/$node"
+
+            if docker cp "$node:$src/." "spindle-logs/$node/"; then
+              ls -la "spindle-logs/$node/"
+            else
+              echo "Copy failed for $node; listing container path:"
+              docker exec "$node" ls -la "$src" || docker exec "$node" ls -la "$workdir" || true
+              failed=1
+              continue
+            fi
+            find "spindle-logs/$node/" -type f ! -name 'spindle_output.*' -delete
+
+            echo "::endgroup::"
+          done
+
+          echo "Collected tree:"
+          ls -R spindle-logs/ || true
+          exit "$failed"
+
+
+      - name: Upload Spindle logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: spindle-logs-flux
+          path: spindle-logs/
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Bring spindle-flux-ubuntu down
+        id: flux-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-flux-ubuntu
+          docker compose down

--- a/.github/workflows/ci-serial-arm64-artifacts.yml
+++ b/.github/workflows/ci-serial-arm64-artifacts.yml
@@ -1,0 +1,77 @@
+name: ci-serial-arm64-artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  spindle-serial-ubuntu_arm64:
+    name: Testsuite (Serial, Ubuntu, arm64)
+    environment: Spindle CI
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@16feee727cbdc83b6a014e6cc26fec4a79bcf30c
+        with:
+          version: latest
+
+      - name: Build spindle-serial-ubuntu image
+        id: serial-ubuntu-build
+        run: |
+          cd containers/spindle-serial-ubuntu
+          docker compose --progress=plain build
+
+      - name: Bring spindle-serial-ubuntu up
+        id: serial-ubuntu-up
+        run: |
+          cd containers/spindle-serial-ubuntu
+          docker compose up -d
+
+      - name: Verify munge works in spindle-serial-ubuntu
+        id: serial-ubuntu-munge
+        run: |
+          docker exec spindlenode bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-serial-ubuntu testsuite
+        id: serial-ubuntu-testsuite
+        run: |
+          docker exec spindlenode bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 ./runTests'
+
+      - name: Collect Spindle logs from container
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          mkdir -p spindle-logs
+          workdir=$(docker inspect -f '{{.Config.WorkingDir}}' spindlenode)
+          echo "Container WorkingDir: ${workdir:-<empty>}"
+          src="${workdir:?WorkingDir was empty - cannot resolve log path}/Spindle-build/testsuite"
+          docker cp "spindlenode:$src/." spindle-logs/ || {
+            echo "Copy failed; listing container path:"
+            docker exec spindlenode ls -la "$src" || docker exec spindlenode ls -la "$workdir"
+            exit 1
+          }
+          ls -la spindle-logs/
+
+      - name: Upload Spindle logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: spindle-logs-serial-arm64
+          path: spindle-logs/spindle_output.*
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Bring spindle-serial-ubuntu down
+        id: serial-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-serial-ubuntu
+          docker compose down

--- a/.github/workflows/ci-serial-x86-artifacts.yml
+++ b/.github/workflows/ci-serial-x86-artifacts.yml
@@ -1,0 +1,77 @@
+name: ci-serial-x86-artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  spindle-serial-ubuntu_x86:
+    name: Testsuite (Serial, Ubuntu, x86)
+    environment: Spindle CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@16feee727cbdc83b6a014e6cc26fec4a79bcf30c
+        with:
+          version: latest
+
+      - name: Build spindle-serial-ubuntu image
+        id: serial-ubuntu-build
+        run: |
+          cd containers/spindle-serial-ubuntu
+          docker compose --progress=plain build
+
+      - name: Bring spindle-serial-ubuntu up
+        id: serial-ubuntu-up
+        run: |
+          cd containers/spindle-serial-ubuntu
+          docker compose up -d
+
+      - name: Verify munge works in spindle-serial-ubuntu
+        id: serial-ubuntu-munge
+        run: |
+          docker exec spindlenode bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-serial-ubuntu testsuite
+        id: serial-ubuntu-testsuite
+        run: |
+          docker exec spindlenode bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 ./runTests'
+
+      - name: Collect Spindle logs from container
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          mkdir -p spindle-logs
+          workdir=$(docker inspect -f '{{.Config.WorkingDir}}' spindlenode)
+          echo "Container WorkingDir: ${workdir:-<empty>}"
+          src="${workdir:?WorkingDir was empty - cannot resolve log path}/Spindle-build/testsuite"
+          docker cp "spindlenode:$src/." spindle-logs/ || {
+            echo "Copy failed; listing container path:"
+            docker exec spindlenode ls -la "$src" || docker exec spindlenode ls -la "$workdir"
+            exit 1
+          }
+          ls -la spindle-logs/
+
+      - name: Upload Spindle logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: spindle-logs-serial-x86
+          path: spindle-logs/spindle_output.*
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Bring spindle-serial-ubuntu down
+        id: serial-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-serial-ubuntu
+          docker compose down

--- a/.github/workflows/ci-slurm-artifacts.yml
+++ b/.github/workflows/ci-slurm-artifacts.yml
@@ -1,0 +1,121 @@
+name: ci-slurm-artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  spindle-slurm-ubuntu:
+    name: Testsuite (Slurm rshlaunch, Ubuntu)
+    environment: Spindle CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@16feee727cbdc83b6a014e6cc26fec4a79bcf30c
+        with:
+          version: latest
+
+      - name: Login to GitHub Container Registry
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate MariaDB configuration
+        id: slurm-ubuntu-mariadb
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          ./generate_config.sh
+
+      - name: Build spindle-slurm-ubuntu image
+        id: slurm-ubuntu-build
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          docker compose --progress=plain build
+
+      - name: Bring spindle-slurm-ubuntu up
+        id: slurm-ubuntu-up
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          docker compose up -d --wait --wait-timeout 120
+
+      - name: Verify munge works in spindle-slurm-ubuntu
+        id: slurm-ubuntu-munge
+        run: |
+          docker exec slurm-head bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-slurm-ubuntu testsuite
+        id: slurm-ubuntu-testsuite
+        run: |
+          docker exec slurm-head bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 salloc -n${workers} -N${workers} ./runTests ${workers}'
+
+
+      - name: Collect Spindle logs from containers
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          failed=0
+          for node in slurm-head slurm-node-1 slurm-node-2 slurm-node-3 slurm-node-4; do
+            echo "::group::Collecting logs from $node"
+
+            if ! workdir=$(docker inspect -f '{{.Config.WorkingDir}}' "$node" 2>/dev/null); then
+              echo "Container $node not found; skipping."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -z "$workdir" ]; then
+              echo "WorkingDir empty for $node; cannot resolve log path."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            src="$workdir/Spindle-build/testsuite"
+            mkdir -p "spindle-logs/$node"
+
+            if docker cp "$node:$src/." "spindle-logs/$node/"; then
+              ls -la "spindle-logs/$node/"
+            else
+              echo "Copy failed for $node; listing container path:"
+              docker exec "$node" ls -la "$src" || docker exec "$node" ls -la "$workdir" || true
+              failed=1
+              continue
+            fi
+            find "spindle-logs/$node/" -type f ! -name 'spindle_output.*' -delete
+
+            echo "::endgroup::"
+          done
+
+          echo "Collected tree:"
+          ls -R spindle-logs/ || true
+          exit "$failed"
+
+
+      - name: Upload Spindle logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: spindle-logs-slurm
+          path: spindle-logs/
+          retention-days: 7
+          if-no-files-found: warn
+
+
+      - name: Bring spindle-slurm-ubuntu down
+        id: slurm-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          docker compose down

--- a/.github/workflows/ci-slurm-plugin-artifacts.yml
+++ b/.github/workflows/ci-slurm-plugin-artifacts.yml
@@ -1,0 +1,123 @@
+name: ci-slurm-plugin-artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  spindle-slurm-plugin-ubuntu:
+    name: Testsuite (Slurm Plugin, Ubuntu)
+    environment: Spindle CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@16feee727cbdc83b6a014e6cc26fec4a79bcf30c
+        with:
+          version: latest
+
+      - name: Login to GitHub Container Registry
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate MariaDB configuration
+        id: slurm-ubuntu-mariadb
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-plugin
+          ./generate_config.sh
+
+      - name: Build spindle-slurm-plugin-ubuntu image
+        id: slurm-ubuntu-build
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-plugin
+          docker compose --progress=plain build
+
+      - name: Bring spindle-slurm-plugin-ubuntu up
+        id: slurm-ubuntu-up
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-plugin
+          docker compose up -d --wait --wait-timeout 120
+
+      - name: Verify munge works in spindle-slurm-plugin-ubuntu
+        id: slurm-ubuntu-munge
+        run: |
+          docker exec slurm-plugin-head bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-slurm-plugin-ubuntu testsuite
+        id: slurm-ubuntu-testsuite
+        run: |
+          docker exec slurm-plugin-head bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 salloc -n${workers} -N${workers} ./runTests ${workers}'
+
+      - name: Run spindle-slurm-plugin-ubuntu session testsuite
+        id: slurm-ubuntu-testsuite-sessions
+        run: |
+          docker exec slurm-plugin-head bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 salloc -n${workers} -N${workers} --spindle-session ./runTests ${workers}'
+
+      - name: Collect Spindle logs from containers
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          failed=0
+          for node in slurm-head slurm-node-1 slurm-node-2 slurm-node-3 slurm-node-4; do
+            echo "::group::Collecting logs from $node"
+
+            if ! workdir=$(docker inspect -f '{{.Config.WorkingDir}}' "$node" 2>/dev/null); then
+              echo "Container $node not found; skipping."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -z "$workdir" ]; then
+              echo "WorkingDir empty for $node; cannot resolve log path."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            src="$workdir/Spindle-build/testsuite"
+            mkdir -p "spindle-logs/$node"
+
+            if docker cp "$node:$src/." "spindle-logs/$node/"; then
+              ls -la "spindle-logs/$node/"
+            else
+              echo "Copy failed for $node; listing container path:"
+              docker exec "$node" ls -la "$src" || docker exec "$node" ls -la "$workdir" || true
+              failed=1
+              continue
+            fi
+            find "spindle-logs/$node/" -type f ! -name 'spindle_output.*' -delete
+
+            echo "::endgroup::"
+          done
+
+          echo "Collected tree:"
+          ls -R spindle-logs/ || true
+          exit "$failed"
+
+      - name: Upload Spindle logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: spindle-logs-slurm-plugin
+          path: spindle-logs/
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Bring spindle-slurm-plugin-ubuntu down
+        id: slurm-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-plugin
+          docker compose down

--- a/.github/workflows/ci-slurm-srun-artifacts.yml
+++ b/.github/workflows/ci-slurm-srun-artifacts.yml
@@ -1,0 +1,120 @@
+name: ci-slurm-srun-artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  spindle-slurm-srun-ubuntu:
+    name: Testsuite (Slurm srun, Ubuntu)
+    environment: Spindle CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@16feee727cbdc83b6a014e6cc26fec4a79bcf30c
+        with:
+          version: latest
+
+      - name: Login to GitHub Container Registry
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate MariaDB configuration
+        id: slurm-ubuntu-mariadb
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-srun
+          ./generate_config.sh
+
+      - name: Build spindle-slurm-ubuntu image
+        id: slurm-ubuntu-build
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-srun
+          docker compose --progress=plain build
+
+      - name: Bring spindle-slurm-ubuntu up
+        id: slurm-ubuntu-up
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-srun
+          docker compose up -d --wait --wait-timeout 120
+
+      - name: Verify munge works in spindle-slurm-srun-ubuntu
+        id: slurm-ubuntu-munge
+        run: |
+          docker exec slurm-srun-head bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-slurm-srun-ubuntu testsuite
+        id: slurm-ubuntu-testsuite
+        run: |
+          docker exec slurm-srun-head bash -c 'cd Spindle-build/testsuite && SPINDLE_DEBUG=3 salloc -n${workers} -N${workers} ./runTests ${workers}'
+
+      - name: Collect Spindle logs from containers
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          failed=0
+          for node in slurm-head slurm-srun-node-1 slurm-srun-node-1 slurm-srun-node-2 slurm-srun-node-3 slurm-srun-node-4; do
+            echo "::group::Collecting logs from $node"
+
+            if ! workdir=$(docker inspect -f '{{.Config.WorkingDir}}' "$node" 2>/dev/null); then
+              echo "Container $node not found; skipping."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -z "$workdir" ]; then
+              echo "WorkingDir empty for $node; cannot resolve log path."
+              failed=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            src="$workdir/Spindle-build/testsuite"
+            mkdir -p "spindle-logs/$node"
+
+            if docker cp "$node:$src/." "spindle-logs/$node/"; then
+              ls -la "spindle-logs/$node/"
+            else
+              echo "Copy failed for $node; listing container path:"
+              docker exec "$node" ls -la "$src" || docker exec "$node" ls -la "$workdir" || true
+              failed=1
+              continue
+            fi
+            find "spindle-logs/$node/" -type f ! -name 'spindle_output.*' -delete
+
+            echo "::endgroup::"
+          done
+
+          echo "Collected tree:"
+          ls -R spindle-logs/ || true
+          exit "$failed"
+
+
+      - name: Upload Spindle logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: spindle-logs-slurm-srun
+          path: spindle-logs/
+          retention-days: 7
+          if-no-files-found: warn
+
+
+      - name: Bring spindle-slurm-ubuntu down
+        id: slurm-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing-srun
+          docker compose down


### PR DESCRIPTION
These workflows are intentionally kept simple.
  * No changes to testsuite/runTests
  * hardcoded SPINDLE_DEBUG=3
  * No test subsetting
  * No options for repeated tests
  * No crash tests
  * Lots of code duplication
  * No log-only-on-failure option

Originally generated with Claude Code + Opus, followed by a fair amount of human debugging/refinement.